### PR TITLE
Use errno for testing error type

### DIFF
--- a/t/error.t
+++ b/t/error.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Mojo::IRC;
 use Test::More;
+use Errno ();
 
 my $port = Mojo::IOLoop->generate_port;
 my $irc = Mojo::IRC->new(server => "localhost:$port");
@@ -26,7 +27,7 @@ Mojo::IOLoop->server(
   $irc->server("localhost:$bad_port");
   $irc->connect(sub {
     my($irc, $error) = @_;
-    like $error, qr{conn}i, 'could not connect';
+    ok $! == Errno::ECONNREFUSED, 'could not connect';
     Mojo::IOLoop->stop;
   });
   Mojo::IOLoop->start;


### PR DESCRIPTION
Original test code is failed on non-English platform.

If user uses Japanese locale, he gets '接続を拒否されました'.
This message is not matched against '/conn/'.

I checked tests applied this patch are passed on Ubuntu 13.10(64bit), Ubuntu 12.04(32bit),
FreeBSD 9.2(64bit), MacOSX 10.9. 

Please check this patch.
