### PR TITLE
Fixed broken tests after Mojolicious 5.0

### DIFF
--- a/t/ctcp.t
+++ b/t/ctcp.t
@@ -8,12 +8,10 @@ use Test::More;
   require Mojo::IRC;
 }
 
-my $port = Mojo::IOLoop->generate_port;
-my $irc = Mojo::IRC->new(nick => "ctcpman", user => "u1", server => "localhost:$port");
 my $read = '';
 
-Mojo::IOLoop->server(
-  { port => $port },
+my $server = Mojo::IOLoop->server(
+  { address => '127.0.0.1' },
   sub {
     my($self, $stream) = @_;
 
@@ -32,6 +30,10 @@ Mojo::IOLoop->server(
   },
 );
 
+my $port = Mojo::IOLoop->acceptor($server)->handle->sockport;
+
+my $irc = Mojo::IRC->new(nick => "ctcpman", user => "u1", server => "localhost:$port");
+
 $irc->parser(Parse::IRC->new(ctcp => 1));
 
 {
@@ -41,6 +43,7 @@ $irc->parser(Parse::IRC->new(ctcp => 1));
   Mojo::IOLoop->start;
 
   delete $action->{raw_line};
+  no warnings 'qw';
   is_deeply(
     $action,
     {

--- a/t/error.t
+++ b/t/error.t
@@ -4,26 +4,28 @@ use Mojo::IRC;
 use Test::More;
 use Errno ();
 
-my $port = Mojo::IOLoop->generate_port;
-my $irc = Mojo::IRC->new(server => "localhost:$port");
 my $status = 'YIKES';
 
-plan skip_all => 'Could not find any port' unless $port;
-
-Mojo::IOLoop->server(
-  { port => $port },
+my $server = Mojo::IOLoop->server(
+  { address => '127.0.0.1' },
   sub {
     my($ioloop, $stream) = @_;
     Mojo::IOLoop->timer(0.01 => sub { $stream->close });
   },
 );
 
+my $port = Mojo::IOLoop->acceptor($server)->handle->sockport;
+
+my $irc = Mojo::IRC->new(server => "localhost:$port");
+
+plan skip_all => 'Could not find any port' unless $port;
+
 {
   $irc->on(close => sub { $status = 'close'; Mojo::IOLoop->stop });
 }
 
 {
-  my $bad_port = Mojo::IOLoop->generate_port;
+  my $bad_port = Mojo::IOLoop::Server->generate_port;
   $irc->server("localhost:$bad_port");
   $irc->connect(sub {
     my($irc, $error) = @_;

--- a/t/join.t
+++ b/t/join.t
@@ -6,12 +6,11 @@ use Test::More;
 plan skip_all => 'No test data' unless -r 't/data/irc.perl.org';
 plan tests => 9;
 
-my $port = Mojo::IOLoop->generate_port;
 my $irc = Mojo::IRC->new;
 my $read = '';
 
-Mojo::IOLoop->server(
-  { port => $port },
+my $server = Mojo::IOLoop->server(
+  { address => '127.0.0.1' },
   sub {
     my($self, $stream) = @_;
     my($join, $welcome);
@@ -30,6 +29,8 @@ Mojo::IOLoop->server(
     $stream->write(irc_data('irc.perl.org'));
   },
 );
+
+my $port = Mojo::IOLoop->acceptor($server)->handle->sockport;
 
 {
   isa_ok($irc, 'Mojo::IRC', 'Constructor returns right object');

--- a/t/register.t
+++ b/t/register.t
@@ -4,19 +4,12 @@ use Test::More;
 
 plan skip_all => 'reason' if 0;
 
-my $port = Mojo::IOLoop->generate_port;
 my $irc = Mojo::IRC->new;
 my $written = '';
 my $err;
 
-$irc->name("the end");
-$irc->nick("fooman");
-$irc->pass("s4cret");
-$irc->server("localhost:$port");
-$irc->user("foo");
-
-Mojo::IOLoop->server(
-  { port => $port },
+my $server = Mojo::IOLoop->server(
+  { address => '127.0.0.1' },
   sub {
     my($self, $stream) = @_;
     my($join, $welcome);
@@ -27,6 +20,14 @@ Mojo::IOLoop->server(
     });
   },
 );
+
+my $port = Mojo::IOLoop->acceptor($server)->handle->sockport;
+
+$irc->name("the end");
+$irc->nick("fooman");
+$irc->pass("s4cret");
+$irc->server("localhost:$port");
+$irc->user("foo");
 
 $irc->connect(sub { $err = pop; });
 Mojo::IOLoop->start;


### PR DESCRIPTION
Some tests were broken as Mojo::IOLoop->generate_port has been removed.
IOLoop now selects its own port and that is used in tests.

Let me know if I've screwed something up.
