### PR TITLE
stop loop when connections fail in tests to avoid hanging

### DIFF
--- a/t/ctcp.t
+++ b/t/ctcp.t
@@ -35,7 +35,7 @@ $irc->parser(Parse::IRC->new(ctcp => 1));
 {
   my $action;
   $irc->on(ctcp_action => sub { $action = $_[1]; });
-  $irc->connect(sub { diag $_[1] || 'Connected'; });
+  $irc->connect(sub { diag $_[1] || 'Connected'; Mojo::IOLoop->stop if $_[1] });
   Mojo::IOLoop->start;
 
   delete $action->{raw_line};

--- a/t/error.t
+++ b/t/error.t
@@ -39,6 +39,7 @@ Mojo::IOLoop->server(
   $irc->connect(sub {
     my($irc, $error) = @_;
     is $error, '', 'connected';
+    Mojo::IOLoop->stop if $error;
   });
   Mojo::IOLoop->start;
 

--- a/t/join.t
+++ b/t/join.t
@@ -62,7 +62,7 @@ Mojo::IOLoop->server(
   $irc->connect(
     sub {
       my ($irc, $err) = @_;
-      diag $err if $err;
+      diag($err), Mojo::IOLoop->stop if $err;
       $irc->write(JOIN => '#mojo');
     }
   );

--- a/t/register.t
+++ b/t/register.t
@@ -25,7 +25,7 @@ Mojo::IOLoop->server(
   },
 );
 
-$irc->connect(sub { $err = pop; });
+$irc->connect(sub { $err = pop; Mojo::IOLoop->stop if $err; });
 Mojo::IOLoop->start;
 
 is $err, '', 'no error';


### PR DESCRIPTION
Tests are hanging on my perl 5.10.1 due to connection timeouts, these changes allow the tests to fail instead of hang.