### PR TITLE
Emit close event later so it can reconnect

### DIFF
--- a/lib/Mojo/IRC.pm
+++ b/lib/Mojo/IRC.pm
@@ -290,9 +290,9 @@ sub connect {
         close => sub {
           $self or return;
           warn "[$self->{debug_key}] : close\n" if DEBUG;
-          $self->emit('close');
           delete $self->{stream};
           delete $self->{stream_id};
+          $self->emit('close');
         }
       );
       $stream->on(


### PR DESCRIPTION
If the client is disconnected and the "close" event has a callback that reconnects to the server, the "connected" event will fire but it doesn't reconnect. This change moves the "close" event to be emitted after the connection data has been deleted so it reconnects properly.