### PR TITLE
allow disconnect() call without callback

### DIFF
--- a/lib/Mojo/IRC.pm
+++ b/lib/Mojo/IRC.pm
@@ -366,12 +366,12 @@ sub disconnect {
       "QUIT\r\n",
       sub {
         $self->{stream}->close;
-        $self->$cb;
+        $self->$cb if $cb;
       }
     );
   }
   else {
-    $self->$cb;
+    $self->$cb if $cb;
   }
 
   $self;


### PR DESCRIPTION
Simple change to allow calling $irc->disconnect with no callback.