### PR TITLE
Add async methods for running actions on irc server

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,8 +2,9 @@ Revision history for perl distribution Mojo-IRC
 
 0.22 Not Released
  - Add Mojo::IRC::UA
- - Add Mojo::IRC::UA->nick() method
+ - Add Mojo::IRC::UA->channels() method
  - Add Mojo::IRC::UA->join_channel() method
+ - Add Mojo::IRC::UA->nick() method
 
 0.21 2015-05-31T07:54:33+0200
  - Deprecated MOJO_IRC_OFFLINE in favor of Test::Mojo::IRC

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for perl distribution Mojo-IRC
 
 0.22 Not Released
  - Add Mojo::IRC::UA
+ - Add Mojo::IRC::UA->nick() method
 
 0.21 2015-05-31T07:54:33+0200
  - Deprecated MOJO_IRC_OFFLINE in favor of Test::Mojo::IRC

--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ Revision history for perl distribution Mojo-IRC
  - Add Mojo::IRC::UA->channel_topic() method
  - Add Mojo::IRC::UA->join_channel() method
  - Add Mojo::IRC::UA->nick() method
+ - Add Mojo::IRC::UA->whois() method
 
 0.21 2015-05-31T07:54:33+0200
  - Deprecated MOJO_IRC_OFFLINE in favor of Test::Mojo::IRC

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for perl distribution Mojo-IRC
 0.22 Not Released
  - Add Mojo::IRC::UA
  - Add Mojo::IRC::UA->channels() method
+ - Add Mojo::IRC::UA->channel_topic() method
  - Add Mojo::IRC::UA->join_channel() method
  - Add Mojo::IRC::UA->nick() method
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl distribution Mojo-IRC
 
+0.22 Not Released
+ - Add Mojo::IRC::UA
+
 0.21 2015-05-31T07:54:33+0200
  - Deprecated MOJO_IRC_OFFLINE in favor of Test::Mojo::IRC
 

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for perl distribution Mojo-IRC
  - Add Mojo::IRC::UA
  - Add Mojo::IRC::UA->channels() method
  - Add Mojo::IRC::UA->channel_topic() method
+ - Add Mojo::IRC::UA->channel_users() method
  - Add Mojo::IRC::UA->join_channel() method
  - Add Mojo::IRC::UA->nick() method
  - Add Mojo::IRC::UA->whois() method

--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for perl distribution Mojo-IRC
 0.22 Not Released
  - Add Mojo::IRC::UA
  - Add Mojo::IRC::UA->nick() method
+ - Add Mojo::IRC::UA->join_channel() method
 
 0.21 2015-05-31T07:54:33+0200
  - Deprecated MOJO_IRC_OFFLINE in favor of Test::Mojo::IRC

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,8 @@
 # You can install this projct with curl -L http://cpanmin.us | perl - https://github.com/jhthorsen/mojo-irc/archive/master.tar.gz
-requires 'IRC::Utils' => '0.12';
-requires 'Mojolicious' => '4.30';
-requires 'Parse::IRC' => '1.20';
+requires 'IRC::Utils'    => '0.12';
+requires 'List::Util'    => '1.00';
+requires 'Mojolicious'   => '4.30';
+requires 'Parse::IRC'    => '1.20';
 requires 'Unicode::UTF8' => '0.59';
+
 test_requires "Test::More" => "0.88";

--- a/lib/Mojo/IRC/UA.pm
+++ b/lib/Mojo/IRC/UA.pm
@@ -1,0 +1,119 @@
+package Mojo::IRC::UA;
+
+=head1 NAME
+
+Mojo::IRC::UA - IRC Client with sugar on top
+
+=head1 SYNOPSIS
+
+  use Mojo::IRC::UA;
+  my $irc = Mojo::IRC::UA->new;
+
+=head1 DESCRIPTION
+
+L<Mojo::IRC::UA> is a module which extends L<Mojo::IRC> with methods
+that can track changes in state on the IRC server.
+
+This module is EXPERIMENTAL and can change without warning.
+
+=cut
+
+use Mojo::Base 'Mojo::IRC';
+use List::Util 'all';
+
+=head1 ATTRIBUTES
+
+L<Mojo::IRC::UA> inherits all attributes from L<Mojo::IRC> and implements the
+following new ones.
+
+=head2 op_timeout
+
+  $int = $self->op_timeout;
+  $self = $self->op_timeout($int);
+
+Max number of seconds to wait for a response from the IRC server.
+
+=cut
+
+has op_timeout => 10;
+
+=head1 EVENTS
+
+L<Mojo::IRC::UA> inherits all events from L<Mojo::IRC> and implements the
+following new ones.
+
+=head1 METHODS
+
+L<Mojo::IRC::UA> inherits all methods from L<Mojo::IRC> and implements the
+following new ones.
+
+=cut
+
+sub _write_and_wait {
+  my ($self, $msg, $look_for, $handler) = @_;
+  my ($tid, $timeout, @subscriptions);
+
+  # This method will send a IRC command to the server and wait for a
+  # corresponding IRC event is returned from the server. On such an
+  # event, the $handler callback will be called, but only if the event
+  # received match the rules set in $look_for.
+
+  # @subscriptions keeps track for the "private" IRC event handlers
+  # for this method call, so we won't mess up other calls to
+  # _write_and_wait() at the same time.
+
+  Scalar::Util::weaken($self);
+
+  # We want a "master timeout" as well, in case the server never send
+  # us any response.
+  $tid = Mojo::IOLoop->timer(
+    ($timeout = $self->op_timeout),
+    sub {
+      $self->unsubscribe(shift @subscriptions, shift @subscriptions) while @subscriptions;
+      $self->$handler(err_timeout => "Response timeout after ${timeout}s.", {});
+    }
+  );
+
+  # Set up which IRC events to look for
+  for my $event (keys %$look_for) {
+    my $needle = $look_for->{$event};
+    push @subscriptions, $event, $self->on(
+      $event => sub {
+        my ($self, $msg) = @_;
+        return unless all { +(/^\d/ ? $msg->{params}[$_] : $msg->{$_}) // '' eq $needle->{$_} } keys %$needle;
+        Mojo::IOLoop->remove($tid);
+        $self->unsubscribe(shift @subscriptions, shift @subscriptions) while @subscriptions;
+        $self->$handler($event => '', $msg);
+      }
+    );
+  }
+
+  # Write the command to the IRC server and stop looking for events
+  # if the write fails.
+  $self->write(
+    $msg->{raw_line},
+    sub {
+      return unless $_[1];    # no error
+      Mojo::IOLoop->remove($tid);
+      $self->unsubscribe(shift @subscriptions, shift @subscriptions) while @subscriptions;
+      $self->$handler(err_write => $_[1], {});
+    }
+  );
+
+  return $self;
+}
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright (C) 2014, Jan Henning Thorsen
+
+This program is free software, you can redistribute it and/or modify it under
+the terms of the Artistic License version 2.0.
+
+=head1 AUTHOR
+
+Jan Henning Thorsen - C<jhthorsen@cpan.org>
+
+=cut
+
+1;

--- a/lib/Test/Mojo/IRC.pm
+++ b/lib/Test/Mojo/IRC.pm
@@ -236,9 +236,10 @@ sub import {
   my $arg    = shift // '';
   my $caller = caller;
 
-  return unless $arg eq '-basic';
+  return unless $arg =~ /^(?:-basic|-ua)$/;
   $_->import for qw(strict warnings utf8);
   feature->import(':5.10');
+  eval "require Mojo::IRC::UA;1" or die $@ if $arg eq '-ua';
   eval "package $caller; use Test::More; 1" or die $@;
 }
 

--- a/t/ua-channel-topic.t
+++ b/t/ua-channel-topic.t
@@ -1,0 +1,75 @@
+use Test::Mojo::IRC -ua;
+
+my $t      = Test::Mojo::IRC->new;
+my $server = $t->start_server;
+my $irc    = Mojo::IRC::UA->new(server => $server, user => "test$$");
+
+$irc->connect(sub { Mojo::IOLoop->stop });
+Mojo::IOLoop->start;
+
+{
+  my $err;
+  $irc->channel_topic("", "0", sub { $err = $_[1]; Mojo::IOLoop->stop });
+  is $err, 'Cannot get/set topic without channel name.', 'channel name missing';
+}
+
+{
+  my $err;
+  $irc->channel_topic("channel with space", "", sub { $err = $_[1]; Mojo::IOLoop->stop });
+  is $err, 'Cannot get/set topic on channel with spaces.', 'channel name with whitespace';
+}
+
+$t->run(
+  [qr{TOPIC} => ['main', 'topic.irc']],
+  sub {
+    my ($err, $topic);
+    $irc->channel_topic("#convos", sub { ($err, $topic) = @_[1, 2]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, '', 'get no error';
+    is_deeply($topic, {message => 'some cool topic'}, 'got topic');
+  },
+);
+
+$t->run(
+  [qr{TOPIC} => ['main', 'cannot-set.irc']],
+  sub {
+    my $err;
+    $irc->channel_topic("#convos", "cannot set topic?", sub { $err = $_[1]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, "You're not on that channel", 'cannot set topic';
+  },
+);
+
+$t->run(
+  [qr{TOPIC} => ['main', 'no-topic.irc']],
+  sub {
+    my ($err, $topic);
+    $irc->channel_topic("#test_channel_topic", sub { ($err, $topic) = @_[1, 2]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, '', 'get no topic error';
+    is_deeply($topic, {message => ''}, 'got no topic');
+  },
+);
+
+$t->run(
+  [qr{TOPIC} => ['main', 'set.irc']],
+  sub {
+    my $err;
+    $irc->channel_topic("#test_channel_topic", "awesomeness", sub { $err = $_[1]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, "", 'set topic';
+  },
+);
+
+done_testing;
+
+__DATA__
+@@ topic.irc
+:hybrid8.debian.local 332 test18655 #convos :some cool topic
+:hybrid8.debian.local 333 test18655 #convos jhthorsen!jhthorsen@i.love.debian.org 1432932059
+@@ cannot-set.irc
+:hybrid8.debian.local 442 test18655 #convos :You're not on that channel
+@@ set.irc
+:test20949!test20949@i.love.debian.org TOPIC #test_channel_topic :awesomeness
+@@ no-topic.irc
+:hybrid8.debian.local 331 test18655 #test_channel_topic :No topic is set.

--- a/t/ua-channel-users.t
+++ b/t/ua-channel-users.t
@@ -1,0 +1,38 @@
+use Test::Mojo::IRC -ua;
+
+my $t      = Test::Mojo::IRC->new;
+my $server = $t->start_server;
+my $irc    = Mojo::IRC::UA->new(server => $server, user => "test$$");
+
+$irc->connect(sub { Mojo::IOLoop->stop });
+Mojo::IOLoop->start;
+
+{
+  my $err;
+  $irc->channel_users("", sub { $err = $_[1]; Mojo::IOLoop->stop });
+  is $err, 'Cannot get users without channel name.', 'channel name missing';
+}
+
+$t->run(
+  [qr{NAMES} => ['main', 'convos-names.irc']],
+  sub {
+    my ($err, $users);
+
+    #for testing with live server:
+    #$irc->join_channel("#convos", sub { Mojo::IOLoop->stop });
+    #Mojo::IOLoop->start;
+    $irc->channel_users("#convos", sub { ($err, $users) = @_[1, 2]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, '', 'no error';
+    is_deeply($users, {foo => {mode => '+'}, bar => {mode => '@'}, test6851 => {mode => ''}, batman => {mode => '@'},},
+      'users');
+  },
+);
+
+done_testing;
+
+__DATA__
+@@ convos-names.irc
+:hybrid8.debian.local 353 test6851 = #convos :test6851 @batman
+:hybrid8.debian.local 353 test6851 = #convos :@bar +foo
+:hybrid8.debian.local 366 test6851 #convos :End of /NAMES list.

--- a/t/ua-channels.t
+++ b/t/ua-channels.t
@@ -1,0 +1,32 @@
+use Test::Mojo::IRC -ua;
+
+my $t      = Test::Mojo::IRC->new;
+my $server = $t->start_server;
+my $irc    = Mojo::IRC::UA->new(server => $server, user => "test$$");
+
+$irc->connect(sub { Mojo::IOLoop->stop });
+Mojo::IOLoop->start;
+
+$t->run(
+  [qr{LIST} => ['main', 'channel-list.irc']],
+  sub {
+    my ($err, $channels);
+    $irc->channels(sub { ($err, $channels) = @_[1, 2]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, '', 'err';
+    is_deeply(
+      $channels,
+      {'#test123' => {n_users => 1, topic => '[+nt]'}, '#convos' => {n_users => 4, topic => '[+nt] some cool topic'},},
+      'channels'
+    );
+  },
+);
+
+done_testing;
+
+__DATA__
+@@ channel-list.irc
+:hybrid8.debian.local 321 test10409 Channel :Users  Name
+:hybrid8.debian.local 322 test10409 #test123 1 :[+nt]
+:hybrid8.debian.local 322 test10409 #convos 4 :[+nt] some cool topic
+:hybrid8.debian.local 323 test10409 :End of /LIST

--- a/t/ua-join-channel.t
+++ b/t/ua-join-channel.t
@@ -1,0 +1,60 @@
+use Test::Mojo::IRC -ua;
+
+my $t      = Test::Mojo::IRC->new;
+my $server = $t->start_server;
+my $irc    = Mojo::IRC::UA->new(server => $server, user => "test$$");
+
+$irc->connect(sub { Mojo::IOLoop->stop });
+Mojo::IOLoop->start;
+
+{
+  my $err;
+  $irc->join_channel("", sub { $err = $_[1]; Mojo::IOLoop->stop });
+  is $err, 'Cannot join without channel name.', 'channel name missing';
+}
+
+{
+  my $err;
+  $irc->join_channel("channel with space", sub { $err = $_[1]; Mojo::IOLoop->stop });
+  is $err, 'Cannot join channel with spaces.', 'channel name with whitespace';
+}
+
+$t->run(
+  [qr{USER} => ['main', 'join-convos.irc']],
+  sub {
+    my ($err, $info);
+    $irc->join_channel("#convos", sub { ($err, $info) = @_[1, 2]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, '', 'channel joined';
+    is_deeply(
+      $info,
+      {
+        topic    => 'some cool topic',
+        topic_by => 'jhthorsen!jhthorsen@i.love.debian.org',
+        users    => {batman => {mode => '@'}, Test21362 => {mode => ''}},
+      },
+      'got channel info'
+    );
+  },
+);
+
+$t->run(
+  [qr{USER} => ['main', 'join-convos.irc']],
+  sub {
+    my $err;
+    $irc->op_timeout(0.3)->join_channel("#convos", sub { $err = $_[1]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    local $TODO = 'Maybe TOPIC can be added to see if already joined?';
+    is $err, 'Response timeout after 0.3s.', 'response timeout';
+  }
+);
+
+done_testing;
+
+__DATA__
+@@ join-convos.irc
+:test21362!test21362@i.love.debian.org JOIN :#convos
+:hybrid8.debian.local 332 test21362 #convos :some cool topic
+:hybrid8.debian.local 333 test21362 #convos jhthorsen!jhthorsen@i.love.debian.org 1432932059
+:hybrid8.debian.local 353 test21362 = #convos :Test21362 @batman
+:hybrid8.debian.local 366 test21362 #convos :End of /NAMES list.

--- a/t/ua-nick.t
+++ b/t/ua-nick.t
@@ -1,0 +1,40 @@
+use Test::Mojo::IRC -ua;
+
+my $t      = Test::Mojo::IRC->new;
+my $server = $t->start_server;
+my $irc    = Mojo::IRC::UA->new(server => $server, user => "test$$");
+
+$irc->connect(sub { Mojo::IOLoop->stop });
+Mojo::IOLoop->start;
+
+$t->run(
+  [qr{NICK testX} => ['main', 'nick-testx.irc']],
+  sub {
+    my ($err, $nick);
+
+    $irc->nick("testX$$", sub { ($err) = @_[1, 2]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, '', 'set nick';
+
+    $irc->nick(sub { ($err, $nick) = @_[1, 2] });
+    is $nick, "testX$$", 'get test';
+  }
+);
+
+$t->run(
+  [qr{NICK jhthorsen} => ['main', 'nick-in-use.irc']],
+  sub {
+    my ($err, $nick);
+    $irc->nick('jhthorsen', sub { ($err) = @_[1, 2]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, 'Nickname is already in use.', 'nick in use';
+  },
+);
+
+done_testing;
+
+__DATA__
+@@ nick-testx.irc
+:test15044!test15044@i.love.debian.org NICK :testX15044
+@@ nick-in-use.irc
+:hybrid8.debian.local 433 testX15044 jhthorsen :Nickname is already in use.

--- a/t/ua-whois.t
+++ b/t/ua-whois.t
@@ -1,0 +1,47 @@
+use Test::Mojo::IRC -ua;
+
+my $t      = Test::Mojo::IRC->new;
+my $server = $t->start_server;
+my $irc    = Mojo::IRC::UA->new(server => $server, user => "test$$");
+
+$irc->connect(sub { Mojo::IOLoop->stop });
+Mojo::IOLoop->start;
+
+{
+  my $err;
+  $irc->whois("", sub { $err = $_[1]; Mojo::IOLoop->stop });
+  is $err, 'Cannot retrieve whois information without target.', 'target missing';
+}
+
+$t->run(
+  [qr{WHOIS} => ['main', 'whois-jhthorsen.irc']],
+  sub {
+    my ($err, $info);
+    $irc->whois("batman", sub { ($err, $info) = @_[1, 2]; Mojo::IOLoop->stop });
+    Mojo::IOLoop->start;
+    is $err, '', 'whois batman';
+    is_deeply(
+      $info,
+      {
+        channels => {'#test123' => {mode => '@'}, '#convos' => {mode => '@'}},
+        idle_for => 17454,
+        name     => 'Jan Henning Thorsen',
+        nick     => 'batman',
+        server   => 'hybrid8.debian.local',
+        user     => 'jhthorsen',
+      },
+      'info'
+    );
+  },
+);
+
+done_testing;
+
+__DATA__
+@@ whois-jhthorsen.irc
+:hybrid8.debian.local 311 test26217 batman jhthorsen i.love.debian.org * :Jan Henning Thorsen
+:hybrid8.debian.local 319 test26217 batman :@#test123 @#convos
+:hybrid8.debian.local 312 test26217 batman hybrid8.debian.local :ircd-hybrid 8.1-debian
+:hybrid8.debian.local 338 test26217 batman 255.255.255.255 :actually using host
+:hybrid8.debian.local 317 test26217 batman 17454 1432930742 :seconds idle, signon time
+:hybrid8.debian.local 318 test26217 batman :End of /WHOIS list.


### PR DESCRIPTION
This pull request has methods which will able this module to get feedback on the actions done on a IRC server, instead of just writing data to the server and manually checking status in event handlers.

Add these methods:
* channel_topic()
* channel_users()
* channels()
* join_channel()
* whois()
* Change nick() to be able to set/get nick async
