### PR TITLE
Fix parsing to allow CR or LF at buffer end.

### DIFF
--- a/lib/Mojo/IRC.pm
+++ b/lib/Mojo/IRC.pm
@@ -566,7 +566,7 @@ sub _read {
   $self->{buffer} .= Unicode::UTF8::decode_utf8($_[0], sub { $_[0] });
 
 CHUNK:
-  while ($self->{buffer} =~ s/^([^\r\n]+)\r\n//m) {
+  while ($self->{buffer} =~ s/^([^\r\n]+)[\r\n]//m) {
     warn "[$self->{debug_key}] >>> $1\n" if DEBUG;
     my $message = $self->parser->parse($1);
     my $command = $message->{command} or next CHUNK;

--- a/lib/Mojo/IRC.pm
+++ b/lib/Mojo/IRC.pm
@@ -566,7 +566,7 @@ sub _read {
   $self->{buffer} .= Unicode::UTF8::decode_utf8($_[0], sub { $_[0] });
 
 CHUNK:
-  while ($self->{buffer} =~ s/^([^\r\n]+)[\r\n]//m) {
+  while ($self->{buffer} =~ s/^([^\015\012]+)[\015\012]//m) {
     warn "[$self->{debug_key}] >>> $1\n" if DEBUG;
     my $message = $self->parser->parse($1);
     my $command = $message->{command} or next CHUNK;

--- a/lib/Test/Mojo/IRC.pm
+++ b/lib/Test/Mojo/IRC.pm
@@ -188,7 +188,7 @@ sub start_server {
           my ($stream, $buf) = @_;
           $self->{from_client} .= $buf;
 
-          while ($buf =~ /\r\n/g) {
+          while ($buf =~ /[\r\n]/g) {
             last unless @{$self->{reply_on}};
             last unless $self->{from_client} =~ $self->{reply_on}[0];
             $self->_concat_server_buf($self->{reply_on}[1]);
@@ -218,7 +218,7 @@ sub _concat_server_buf {
     $buf = Mojo::Util::slurp(File::Spec->catfile(split '/', $$buf));
   }
 
-  $buf =~ s/\r?\n/\r\n/g;
+  $buf =~ s/[\r\n]/\r\n/g;
   $self->{server_buf} .= $buf;
 }
 

--- a/lib/Test/Mojo/IRC.pm
+++ b/lib/Test/Mojo/IRC.pm
@@ -188,7 +188,7 @@ sub start_server {
           my ($stream, $buf) = @_;
           $self->{from_client} .= $buf;
 
-          while ($buf =~ /[\r\n]/g) {
+          while ($buf =~ /[\015\012]/g) {
             last unless @{$self->{reply_on}};
             last unless $self->{from_client} =~ $self->{reply_on}[0];
             $self->_concat_server_buf($self->{reply_on}[1]);
@@ -218,7 +218,7 @@ sub _concat_server_buf {
     $buf = Mojo::Util::slurp(File::Spec->catfile(split '/', $$buf));
   }
 
-  $buf =~ s/[\r\n]/\r\n/g;
+  $buf =~ s/[\015\012]/\015\012/g;
   $self->{server_buf} .= $buf;
 }
 


### PR DESCRIPTION
I started using `Mojo::IRC` and noticed it seemingly not getting any data, even under `DEBUG`. Turns out the goofball server I was talking to only emits `\n`, so `Mojo::IRC::_read` was failing to match. I added square brackets around the closing `\r\n` to allow either and life is good. All existing tests pass.

I added a link to the relevant bit of IRC spec by way of reference (I imagine you guys have spent a lot of time with this document, I just didn't want this hack to seem _entirely_ unfounded :))

> Unfortunately, due to backward compatibility requirements ... any LF or CR anywhere in a message marks the end of that message (instead of requiring CR-LF);

Happy to do any cleanup you'd like, I'd love to use Mojo::IRC for this quick project of mine!