### PR TITLE
Add insecure option for invalid certs with Mojolicious 7.80

### DIFF
--- a/lib/Mojo/IRC.pm
+++ b/lib/Mojo/IRC.pm
@@ -83,7 +83,7 @@ sub connect {
     push @extra, tls_ca   => $tls->{ca} if $tls->{ca};     # not sure why this should be supported, but adding it anyway
     push @extra, tls_cert => $tls->{cert} || DEFAULT_CERT;
     push @extra, tls_key  => $tls->{key} || DEFAULT_KEY;
-    push @extra, tls_verify => 0x00 if defined $tls->{insecure};
+    push @extra, tls_verify => 0x00 if $tls->{insecure};
   }
 
   $port ||= 6667;

--- a/lib/Mojo/IRC.pm
+++ b/lib/Mojo/IRC.pm
@@ -83,6 +83,7 @@ sub connect {
     push @extra, tls_ca   => $tls->{ca} if $tls->{ca};     # not sure why this should be supported, but adding it anyway
     push @extra, tls_cert => $tls->{cert} || DEFAULT_CERT;
     push @extra, tls_key  => $tls->{key} || DEFAULT_KEY;
+    push @extra, tls_verify => 0x00 if defined $tls->{insecure};
   }
 
   $port ||= 6667;
@@ -544,6 +545,11 @@ This can be generated using
 
   # certtool --generate-privkey --outfile client.key
   # certtool --generate-self-signed --load-privkey client.key --outfile client.crt
+
+To disable the verification of server certificates, the "insecure" option
+can be set:
+
+  $self->tls({ insecure => 1 });
 
 =head1 METHODS
 


### PR DESCRIPTION
Mojolicious 7.80 changed Mojo::IOLoop::Client to defer to IO::Socket::SSL's default behavior of verifying server certificates by default. To allow users to disable this we can add an insecure option similarly to Mojo::UserAgent.