### PR TITLE
Passthrough ctcpreply events from Parse::IRC

### DIFF
--- a/lib/Mojo/IRC.pm
+++ b/lib/Mojo/IRC.pm
@@ -322,7 +322,7 @@ sub _legacy_dispatch_message {
   my ($self, $msg) = @_;
   my $event = $msg->{event};
 
-  $event = "irc_$event" unless $event =~ /^(ctcp|err)_/;
+  $event = "irc_$event" unless $event =~ /^(ctcp(reply)?|err)_/;
   warn "[$self->{debug_key}] === $event\n" if DEBUG == 2;
   $self->emit($event => $msg);
 }


### PR DESCRIPTION
Parse::IRC with ctcp => 1 will pass CTCP privmsgs as ctcp_ and CTCP notices as ctcpreply_. Currently ctcp_ events are passed through but ctcpreply_ gets turned into irc_ctcpreply_. ctcpreply should be handled the same way.