### PR TITLE
text for NOTICE is in the second param

### DIFF
--- a/lib/Mojo/IRC.pm
+++ b/lib/Mojo/IRC.pm
@@ -250,7 +250,7 @@ sub irc_notice {
   my ($self, $message) = @_;
 
   # NOTICE AUTH :*** Ident broken or disabled, to continue to connect you must type /QUOTE PASS 21105
-  if ($message->{params}[0] =~ m!Ident broken.*QUOTE PASS (\S+)!) {
+  if ($message->{params}[1] =~ m!Ident broken.*QUOTE PASS (\S+)!) {
     $self->write(QUOTE => PASS => $1);
   }
 }

--- a/t/default-handlers.t
+++ b/t/default-handlers.t
@@ -13,10 +13,10 @@ for my $event (qw( irc_ping irc_nick irc_notice irc_rpl_welcome err_nicknameinus
   ok $irc->has_subscribers($event), "registered $event";
 }
 
-$irc->irc_notice({params => ['yikes!']});
+$irc->irc_notice({params => ['nick', 'yikes!']});
 is_deeply \@main::buf, [], 'no pass notice';
 
-$irc->irc_notice({params => ['Ident broken stuff and other things QUOTE PASS S3creT']});
+$irc->irc_notice({params => ['nick', 'Ident broken stuff and other things QUOTE PASS S3creT']});
 is_deeply \@main::buf, ["QUOTE PASS S3creT\r\n"], 'pass notice';
 
 @main::buf = ();


### PR DESCRIPTION
RFC2812 states that the text for NOTICE is in the second parameter
```
3.3.2 Notice

      Command: NOTICE
   Parameters: <msgtarget> <text>
   ```